### PR TITLE
Point group

### DIFF
--- a/spec/unit/point_grouper_spec.cr
+++ b/spec/unit/point_grouper_spec.cr
@@ -1,0 +1,28 @@
+require "../spec_helper"
+
+describe Contours::PointGrouper do
+  describe ".group" do
+    context "when there are no points" do
+      it "returns an empty array" do
+        groups = Contours::PointGrouper.group([] of Point)
+
+        groups.should eq([] of Array(Point))
+      end
+    end
+
+    context "when there is a single group" do
+      it "returns all points in one grouping" do
+        points = [
+          Point.new(2, 3),
+          Point.new(3, 3),
+          Point.new(2, 4),
+          Point.new(3, 4)
+        ]
+
+        groups = Contours::PointGrouper.group(points)
+
+        groups.first.should contain_exactly(points)
+      end
+    end
+  end
+end

--- a/spec/unit/point_grouper_spec.cr
+++ b/spec/unit/point_grouper_spec.cr
@@ -10,6 +10,15 @@ describe Contours::PointGrouper do
       end
     end
 
+    context "when there is just one point" do
+      it "returns a group of that one point" do
+        points = [Point.new(0, 0)]
+        groups = Contours::PointGrouper.group(points)
+
+        groups.should eq([points])
+      end
+    end
+
     context "when there is a single group" do
       it "returns all points in one grouping" do
         points = [

--- a/spec/unit/point_grouper_spec.cr
+++ b/spec/unit/point_grouper_spec.cr
@@ -30,7 +30,37 @@ describe Contours::PointGrouper do
 
         groups = Contours::PointGrouper.group(points)
 
+        groups.size.should eq(1)
         groups.first.should contain_exactly(points)
+      end
+    end
+
+    context "when there are multiple groups" do
+      it "returns multiple point groups" do
+        small = [
+          Point.new(11, 10),
+          Point.new(12, 10),
+        ]
+        medium = [
+          Point.new(6, 4),
+          Point.new(6, 5),
+          Point.new(7, 5),
+        ]
+        large = [
+          Point.new(2, 3),
+          Point.new(3, 3),
+          Point.new(2, 4),
+          Point.new(3, 4)
+        ]
+        points = small + medium + large
+
+        groups = Contours::PointGrouper.group(points)
+        groups.sort_by!(&.size)
+
+        groups.size.should eq(3)
+        groups[0].should contain_exactly(small)
+        groups[1].should contain_exactly(medium)
+        groups[2].should contain_exactly(large)
       end
     end
   end

--- a/src/charms/spec.cr
+++ b/src/charms/spec.cr
@@ -1,0 +1,29 @@
+module Spec
+  class ContainExactlyExpectation(T)
+    def initialize(@expected_value : Array(T))
+    end
+
+    def match(actual_value : Array(T))
+      return false if actual_value.size != @expected_value.size
+      actual_value.each do |value|
+        return false if @expected_value.count(value) !=
+          actual_value.count(value)
+      end
+      true
+    end
+
+    def failure_message(actual_value)
+      "Expected: #{actual_value.inspect}\nto have the same elements as: #{@expected_value.inspect}"
+    end
+
+    def negative_failure_message(actual_value)
+      "Expected: value #{actual_value.inspect}\n not to have the same elements as: #{@expected_value.inspect}"
+    end
+  end
+
+  module Expectations
+    def contain_exactly(array)
+      Spec::ContainExactlyExpectation.new(array)
+    end
+  end
+end

--- a/src/contours/point_grouper.cr
+++ b/src/contours/point_grouper.cr
@@ -5,13 +5,15 @@ class Contours::PointGrouper
     new(points: points).group
   end
 
-  def initialize(@points : Array(Point))
+  def initialize(points : Array(Point))
+    @points = points.clone
   end
 
   def group : Array(Array(Point))
     groups = [] of Array(Point)
     while !@points.empty?
-      groups.push(find_neighbors(@points.first))
+      start_point = @points.shift
+      groups.push(find_neighbors(start_point) + [start_point])
     end
     groups
   end

--- a/src/contours/point_grouper.cr
+++ b/src/contours/point_grouper.cr
@@ -1,0 +1,32 @@
+class Contours::PointGrouper
+  @points = [] of Point
+
+  def self.group(points : Array(Point))
+    new(points: points).group
+  end
+
+  def initialize(@points : Array(Point))
+  end
+
+  def group : Array(Array(Point))
+    groups = [] of Array(Point)
+    while !@points.empty?
+      groups.push(find_neighbors(@points.first))
+    end
+    groups
+  end
+
+  def find_neighbors(point : Point)
+    neighbors = Contours::GridNearestNeighbors.new(
+      origin: point, points: @points
+    ).find
+
+    return neighbors if neighbors.empty?
+
+    @points -= neighbors
+    neighbors.each do |point|
+      neighbors += find_neighbors(point)
+    end
+    neighbors
+  end
+end


### PR DESCRIPTION
This adds a point grouping class. The idea is that I'll have a giant array of all points as a terrain. The terrain will get divided up into bands by height. However, there might be multiple discreet groups that shouldn't use the same path for the outline. That's where this `PointGrouper` comes in.

It finds points by starting with a seed point, using the `GridNearestNeighbors` class to scan for adjacent points, then recursively scanning those points' neighbors. It's similar to a [flood fill algorithm](https://en.wikipedia.org/wiki/Flood_fill).

I also added an expectation method so I could compare arrays of points to see if their contents matched.